### PR TITLE
now runs the create user request for google logins

### DIFF
--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -24,6 +24,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 
+const VITE_CRUD_API = import.meta.env.VITE_CRUD_API;
+
 const formSchema = z.object({
   email: z.string().email({ message: "Please enter a valid email address" }),
   password: z
@@ -67,6 +69,17 @@ export default function LoginForm() {
 
       const token = await user.getIdToken();
       Cookies.set("authToken", token, { expires: 7 });
+
+      await fetch(VITE_CRUD_API, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          userId: result.user.uid,
+          token: token,
+          action: "createUser",
+        }),
+      });
+
       toast.success("Successfully signed in with Google!");
       navigate(from, { replace: true });
     } catch (error) {

--- a/src/components/signup-form.tsx
+++ b/src/components/signup-form.tsx
@@ -23,6 +23,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 
+const VITE_CRUD_API = import.meta.env.VITE_CRUD_API;
+
 const formSchema = z
   .object({
     email: z.string().email({ message: "Please enter a valid email address" }),
@@ -40,8 +42,6 @@ type FormValues = z.infer<typeof formSchema>;
 
 export default function SignupForm() {
   const navigate = useNavigate();
-
-  const VITE_CRUD_API = import.meta.env.VITE_CRUD_API;
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),


### PR DESCRIPTION
firebase email enumeration protection prevents accessing providers of a returned user when signing in through gmail to confirm that they have an existing login. Currently it was creating users in firebase when people logged in without signing up and then preventing them from using the chatbot because the createUser crud lambda function wasn't ran to provision necessary validation resources