### PR TITLE
Fixed persistent state in conversation when logout action

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -60,6 +60,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const logout = async () => {
     try {
       await signOut(auth);
+      localStorage.removeItem("chatbot_conversation");
       Cookies.remove("authToken");
       setUser(null);
     } catch (error) {


### PR DESCRIPTION
- turns out, the 1 hour cache, while great, doesn't allow for logout/login events to reset that state I was talking about. Therefore, whenever a sign-out occurs, this will automatically remove the chatbot_conversation state and can go to the new screen when done so.