### PR TITLE
course fix deduplication + removal

### DIFF
--- a/src/components/Planner.tsx
+++ b/src/components/Planner.tsx
@@ -15,9 +15,13 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
     const [allSemesters, setAllSemesters] = useState(() => {
         const updatedSemesters = { ...semesters };
         Object.keys(updatedSemesters).forEach((yearKey) => {
-            updatedSemesters[yearKey] = updatedSemesters[yearKey].map((semester) => ({
+            updatedSemesters[yearKey] = updatedSemesters[yearKey].map((semester, semIdx) => ({
                 ...semester,
                 isFromTranscript: true, // Mark all semesters as from transcriptData
+                courses: semester.courses.map(course => ({
+                    ...course,
+                    originalLocation: { yearKey, semesterIndex: semIdx } // dragging to origin
+                }))
             }));
         });
         return updatedSemesters;
@@ -75,6 +79,35 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
             console.log("Source year/semester:", sourceYear, sourceSemesterIndex);
             console.log("Target year/semester:", targetYear, targetSemesterIndex);
             console.log("Is suggested course:", isSuggested);
+
+            const courseCode = course.code || course.course_code;
+            if (!isSuggested && course.originalLocation) {
+                const isOriginalLocation = 
+                    targetYear === course.originalLocation.yearKey && 
+                    targetSemesterIndex === course.originalLocation.semesterIndex;
+                
+                if (!isOriginalLocation) {
+                    setError(`${courseCode} can only be moved back to ${prev[course.originalLocation.yearKey][course.originalLocation.semesterIndex].title}`);
+                    return prev;
+                }
+            }
+            
+            // Check if course exists anywhere else in the plan
+            for (const yearKey in prev) {
+                for (let idx = 0; idx < prev[yearKey].length; idx++) {
+                    const semester = prev[yearKey][idx];
+                    // Skip the source semester
+                    if (yearKey === sourceYear && idx === sourceSemesterIndex) continue;
+                    
+                    const exists = semester.courses.some(c => c.course_code === courseCode);
+                    if (exists) {
+                        setError(`${courseCode} is already in ${semester.title}`);
+                        return prev;
+                    }
+                }
+            }
+
+            if (error) return prev;
 
             // Create deep copies to avoid mutation
             const newState = JSON.parse(JSON.stringify(prev));

--- a/src/components/Planner.tsx
+++ b/src/components/Planner.tsx
@@ -79,6 +79,27 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
             console.log("Source year/semester:", sourceYear, sourceSemesterIndex);
             console.log("Target year/semester:", targetYear, targetSemesterIndex);
             console.log("Is suggested course:", isSuggested);
+                        
+            // removal logic
+            const isRemoval = !targetYear || 
+                targetYear === '' || 
+                targetSemesterIndex === undefined || 
+                targetSemesterIndex === null ||
+                targetSemesterIndex < 0; 
+
+            if (isRemoval) {
+                const newState = JSON.parse(JSON.stringify(prev));
+                const sourceSemester = newState[sourceYear]?.[sourceSemesterIndex];
+                if (sourceSemester?.courses) {
+                    const courseIndex = sourceSemester.courses.findIndex(
+                        (c: any) => c.id === courseId
+                    );
+                    if (courseIndex !== -1) {
+                        sourceSemester.courses.splice(courseIndex, 1);
+                    }
+                }
+                return newState;
+            }
 
             const courseCode = course.code || course.course_code;
             if (!isSuggested && course.originalLocation) {
@@ -106,8 +127,6 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
                     }
                 }
             }
-
-            if (error) return prev;
 
             // Create deep copies to avoid mutation
             const newState = JSON.parse(JSON.stringify(prev));
@@ -311,6 +330,9 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
                 expandedCategories={expandedCategories}
                 onToggleCategory={toggleCategory}
                 transcriptData={transcriptData}
+                onDropCourse={(courseId, sourceYear, sourceSemesterIndex) => 
+                    handleDropCourse('', -1, null, sourceYear, sourceSemesterIndex, courseId, false)
+                }
             />
 
             <div className="flex-1 overflow-y-auto p-6">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useRef } from "react";
 import { ChevronDown, ChevronRight, ChevronLeft, NotebookPen, SquareAsterisk } from "lucide-react";
+import { useDrop } from "react-dnd";
 import RequirementCategory from "./RequirementCategory";
 import CourseBox from "./CourseBox";
 import ProgramValidationA from "./ProgramValidationA";
 import FileUploader from "./FileUpload";
 
-// Sidebar Component
 interface SidebarProps {
     requirements: {
         degree: string;
@@ -42,43 +42,57 @@ interface SidebarProps {
     expandedCategories: { [key: number]: boolean };
     onToggleCategory: (index: number) => void;
     transcriptData: any;
+    onDropCourse?: (courseId: string, sourceYear: string, sourceSemesterIndex: number) => void;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
     requirements,
-    //expandedCategories,
-    //onToggleCategory,
-    transcriptData
+    transcriptData,
+    onDropCourse
 }) => {
-    const [isExpanded, setIsExpanded] = useState(true); // Track sidebar expansion state
+    const [isExpanded, setIsExpanded] = useState(true);
     const [expandedSubcategories, setExpandedSubcategories] = useState<Record<string, boolean>>({});
-    const [isProgramValidationOpen, setIsProgramValidationOpen] = useState(false); // Track if ProgramValidationA is open
-    const [showUploadView, setShowUploadView] = useState(false); // transcript upload
+    const [isProgramValidationOpen, setIsProgramValidationOpen] = useState(false);
+    const [showUploadView, setShowUploadView] = useState(false);
     const [autoExpandedCategories, setAutoExpandedCategories] = useState<{ [key: number]: boolean }>({});
-    const dropdownRef = useRef<HTMLDivElement>(null); // Ref for the dropdown
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    const [{ isOver }, drop] = useDrop(
+        () => ({
+            accept: "COURSE",
+            drop: (item: any) => {
+                console.log("Dropped on sidebar:", item);
+                if (item.courseId && item.sourceYear !== undefined && item.sourceSemesterIndex !== undefined && onDropCourse) {
+                    onDropCourse(item.courseId, item.sourceYear, item.sourceSemesterIndex);
+                }
+            },
+            collect: (monitor) => ({
+                isOver: monitor.isOver(),
+            }),
+        }),
+        [onDropCourse]
+    );
 
     const handleToggleSidebar = () => {
-        setIsExpanded((prev) => !prev); // Toggle sidebar state
+        setIsExpanded((prev) => !prev);
     };
 
     useEffect(() => {
-        // Automatically collapse categories without suggested courses
         const initialExpandedState: { [key: number]: boolean } = {};
         requirements.forEach((req, reqIdx) => {
           const hasSuggestedCourses = req.categories.some(
             (category: any) => category.suggested && category.suggested.length > 0
           );
-          initialExpandedState[reqIdx] = hasSuggestedCourses; // Expand only if there are suggested courses
+          initialExpandedState[reqIdx] = hasSuggestedCourses;
         });
         setAutoExpandedCategories(initialExpandedState);
       }, [requirements]);
 
       const handleOpenProgramValidation = () => {
-        setIsProgramValidationOpen(true); // Open the ProgramValidationA modal
+        setIsProgramValidationOpen(true);
       };
     
       const handleCloseProgramValidation = (e?: MouseEvent) => {
-        // Ensure clicks inside the dropdown do not close the modal
         if (
           e &&
           dropdownRef.current &&
@@ -86,30 +100,12 @@ const Sidebar: React.FC<SidebarProps> = ({
         ) {
           return;
         }
-        setIsProgramValidationOpen(false); // Close the modal
+        setIsProgramValidationOpen(false);
       };
 
-    // USED TO CALL LAMBDA TO UPDATE PROGRAMS LATER
     const handleSavePrograms = (updatedPrograms: any[]) => {
         console.log("Updated programs:", updatedPrograms);
-
-        // // Example: Call an API endpoint to update the programs
-        // fetch("/api/update-programs", {
-        //     method: "POST",
-        //     headers: {
-        //         "Content-Type": "application/json",
-        //     },
-        //     body: JSON.stringify(updatedPrograms),
-        // })
-        //     .then((response) => response.json())
-        //     .then((data) => {
-        //         console.log("Programs updated successfully:", data);
-        //     })
-        //     .catch((error) => {
-        //         console.error("Error updating programs:", error);
-        //     });
-
-        handleCloseProgramValidation(); // Close the modal
+        handleCloseProgramValidation();
     };
 
     const handleToggleSubcategory = (reqIdx: number, catIdx: number) => {
@@ -120,16 +116,13 @@ const Sidebar: React.FC<SidebarProps> = ({
         }));
     };
 
-    // Check if a subcategory is expanded
     const isSubcategoryExpanded = (reqIdx: number, catIdx: number) => {
         const key = `${reqIdx}-${catIdx}`;
-        // Default to true if not explicitly set
         return expandedSubcategories[key] !== false;
     };
 
     console.log(requirements[0]?.categories?.[0]?.classes);
 
-    // Recursive function to render categories and subcategories
     const renderCategories = (categories: any[], reqIdx: number, parentCatIdx: number = 0) => {
         return categories.map((category, catIdx) => {
             const currentCatIdx = `${parentCatIdx}-${catIdx}`;
@@ -162,7 +155,6 @@ const Sidebar: React.FC<SidebarProps> = ({
 
                     {isSubcategoryExpanded(reqIdx, parseInt(currentCatIdx)) && (
                         <div className="p-2 space-y-1">
-                            {/* Render classes */}
                             {category.classes && category.classes.length > 0 ? (
                                 category.classes.map((course: any, courseIdx: number) => (
                                     <CourseBox
@@ -194,7 +186,6 @@ const Sidebar: React.FC<SidebarProps> = ({
                                 </div>
                             )}
 
-                            {/* Render suggested courses */}
                             {category.suggested && category.suggested.length > 0 && (
                                 <>
                                     <div className="mt-2 mb-1 border-t border-gray-100 pt-1">
@@ -227,7 +218,6 @@ const Sidebar: React.FC<SidebarProps> = ({
                                 </>
                             )}
 
-                            {/* Render subcategories recursively */}
                             {category.categories &&
                                 category.categories.length > 0 &&
                                 renderCategories(category.categories, reqIdx, parseInt(currentCatIdx))}
@@ -242,11 +232,12 @@ const Sidebar: React.FC<SidebarProps> = ({
         <>
             <div className={`${isExpanded ? "w-80" : "w-20"} bg-gray-50 border-r border-gray-200 h-screen transition-all duration-300 flex flex-col`}>
                 
-                {/* Scrollable content - full height */}
-                <div className="flex-1 overflow-y-auto">
+                <div 
+                    ref={drop}
+                    className={`flex-1 overflow-y-auto ${isOver ? 'bg-gray-100' : ''}`}
+                >
                     {isExpanded ? (
                         <div className="p-4">
-                            {/* Sidebar Header */}
                             <div className="flex items-center justify-between mb-6">
                                 <button className="flex items-center gap-2 px-4 py-2 bg-green-400 hover:bg-green-500 rounded-full transition-colors"
                                     onClick={handleOpenProgramValidation}
@@ -262,7 +253,6 @@ const Sidebar: React.FC<SidebarProps> = ({
                                 </button>
                             </div>
 
-                            {/* Sidebar Content */}
                             <h2 className="text-xl font-bold text-gray-900 mb-4">
                                 Degree Requirements
                             </h2>
@@ -312,7 +302,6 @@ const Sidebar: React.FC<SidebarProps> = ({
                     )}
                 </div>
     
-                {/* Sticky Banner at bottom */}
                 <div className="sticky bottom-0 p-4 bg-gray-50">
                     <div 
                         className={`${isExpanded ? "rounded-full" : "cursor-pointer rounded-md"} bg-gray-900 py-3 px-6 flex gap-2 justify-center items-center`}
@@ -336,7 +325,6 @@ const Sidebar: React.FC<SidebarProps> = ({
                 </div>
             </div>
     
-            {/* Modal - unchanged */}
             {isProgramValidationOpen && (
                 <div className="fixed inset-0 bg-black bg-opacity-70 z-[80] flex items-center justify-center">
                     <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-4xl relative">


### PR DESCRIPTION
**Before**: courses were able to be duplicated in any semester (and in the same semester that class was in) + no way of removing individual courses without having to "delete" the semester

**After**: attempts to add the same course in the same semester or different semester in which that same course exists in the planning interface will error out to inform the user. Additionally, now you can just drag a course back into the sidebar and it'll remove the course from the semester.