### PR TITLE
fix: Firefox scrollbar styling compability issue

### DIFF
--- a/src/components/ClassValidationA.tsx
+++ b/src/components/ClassValidationA.tsx
@@ -170,6 +170,11 @@ const ClassValidationA: React.FC<ClassValidationAProps> = ({ onNext, onBack, tra
     <div className="relative w-full max-w-4xl">
       <div ref={scrollRef} className="overflow-y-auto max-h-[90vh] custom-scrollbar rounded-lg bg-gray-50" style={{ paddingRight: '20px' }}>
         <style>{`
+          .custom-scrollbar {
+            scrollbar-width: auto;
+            scrollbar-color: #4ade80 transparent;
+          }
+            
           .custom-scrollbar::-webkit-scrollbar {
             width: 6px;
           }


### PR DESCRIPTION
- simple inline styling fix from CSS Scrollbars Styling Module Level 1 for non-webkit browsers
- existing webkit behavior preserved
- similar green styling but limited gradient and width control

Webkit Supported (Edge/Chrome/Safari):
<img width="744" height="272" alt="image" src="https://github.com/user-attachments/assets/bf09d1e6-6940-42aa-b478-d2615ad9565f" />

Non-Webkit (Firefox)
<img width="742" height="247" alt="image" src="https://github.com/user-attachments/assets/b9aa9c6e-fb14-474d-b335-ae4e3c41ee66" />

Closes #92 