### PR TITLE
feat: clear semester courses

### DIFF
--- a/src/components/Planner.tsx
+++ b/src/components/Planner.tsx
@@ -100,27 +100,19 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
         yearKey: string;
         semesterIndex: number;
         isLastSemester: boolean;
+        action: 'clear' | 'delete';
     } | null>(null);
 
     const errorRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        if (error && errorRef.current) {
+        if (error && scrollContainerRef.current) {
             setTimeout(() => {
-                // Get the scrollable container (which is the parent of the error div)
-                const scrollContainer = errorRef.current?.closest('.overflow-y-auto');
-
-                if (scrollContainer) {
-                    // Calculate the navbar height (adjust this value to match your navbar height)
-                    const navbarHeight = 64; // Example: 64px - adjust this based on your actual navbar height
-
-                    // Scroll within the container, accounting for navbar height
-                    scrollContainer.scrollTo({
-                        top: errorRef.current ? (errorRef.current.offsetTop - navbarHeight - 20) : 0,
+                scrollContainerRef.current?.scrollTo({
+                        top: 0,
                         behavior: 'smooth'
-                    });
-                }
-            }, 100);
+                });
+            }, 200);
         }
     }, [error]);
 
@@ -363,6 +355,20 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
         });
     };
 
+    const handleClearSemester = (yearKey: string, semesterIndex: number) => {
+        if (!semesterToDelete) return;
+
+        setAllSemesters(prev => {
+            const newState = JSON.parse(JSON.stringify(prev));
+            newState[yearKey][semesterIndex].courses = [];
+            return newState;
+        });
+       
+        //Close modal and reset state
+        setShowDeleteModal(false);
+        setSemesterToDelete(null);
+    }
+
     const handleRemoveSemester = (yearKey: string, semesterIndex: number) => {
         if (!semesterToDelete) return;
         
@@ -388,11 +394,11 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
         setSemesterToDelete(null);
     };
 
-    const openDeleteModal = (yearKey: string, semesterIndex: number) => {
+    const openClearDeleteModal = (yearKey: string, semesterIndex: number, action: 'clear' | 'delete') => {
         const yearSemesters = allSemesters[yearKey];
         const isLastSemester = yearSemesters.length === 1;
         
-        setSemesterToDelete({ yearKey, semesterIndex, isLastSemester });
+        setSemesterToDelete({ yearKey, semesterIndex, isLastSemester, action});
         setShowDeleteModal(true);
     };
 
@@ -515,7 +521,9 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
                                         onDropCourse={(course, sourceYear, sourceSemesterIndex, courseId, isSuggested) =>
                                             handleDropCourse(yearKey, idx, course, sourceYear, sourceSemesterIndex, courseId, isSuggested)
                                         }
-                                        onRemoveSemester={() => openDeleteModal(yearKey, idx)}
+                                        onClearSemester={() => openClearDeleteModal(yearKey, idx, 'clear')}
+                                        onRemoveSemester={() => openClearDeleteModal(yearKey, idx, 'delete')}
+                                        onShowError={setError}
                                     />
                                 ))}
                             </div>
@@ -549,15 +557,20 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
                             onClick={(e) => e.stopPropagation()}
                         >
                             <h3 className="text-lg font-semibold mb-4 text-gray-800">
-                                {semesterToDelete.isLastSemester 
-                                    ? `Remove ${semesterToDelete.yearKey.replace("year", "Year ")}?`
-                                    : `Remove ${allSemesters[semesterToDelete.yearKey][semesterToDelete.semesterIndex].title}?`
+                                {semesterToDelete.action === 'clear'
+                                    ? `Clear ${allSemesters[semesterToDelete.yearKey][semesterToDelete.semesterIndex].title}?`
+                                    : semesterToDelete.isLastSemester 
+                                        ? `Remove ${semesterToDelete.yearKey.replace("year", "Year ")}?`
+                                        : `Remove ${allSemesters[semesterToDelete.yearKey][semesterToDelete.semesterIndex].title}?`
+                                
                                 }
                             </h3>
                             <p className="text-sm text-gray-600 mb-6">
-                                {semesterToDelete.isLastSemester
-                                    ? "This will delete the entire year since it's the only semester."
-                                    : "This semester and all its courses will be removed from your plan."
+                                {semesterToDelete.action === 'clear'
+                                    ? "All courses in this semester will be cleared."
+                                    : semesterToDelete.isLastSemester
+                                        ? "This will delete the entire year since it's the only semester."
+                                        : "This semester and all its courses will be removed from your plan."
                                 }
                             </p>
                             
@@ -574,12 +587,16 @@ const Planner: React.FC<PlannerProps> = ({ semesters, requirements, transcriptDa
                                 
                                 <button
                                     className="px-4 py-2 text-sm bg-red-600 text-white rounded hover:bg-red-700"
-                                    onClick={() => handleRemoveSemester(
-                                        semesterToDelete.yearKey, 
-                                        semesterToDelete.semesterIndex
-                                    )}
+                                    onClick={() => {
+                                        if (semesterToDelete.action === 'clear') {
+                                            handleClearSemester(semesterToDelete.yearKey, semesterToDelete.semesterIndex);
+                                        }
+                                        else {
+                                            handleRemoveSemester(semesterToDelete.yearKey, semesterToDelete.semesterIndex);
+                                        }
+                                    }}
                                 >
-                                    Remove
+                                    {semesterToDelete.action === 'clear' ? 'Clear' : 'Remove'}
                                 </button>
                             </div>
                         </div>

--- a/src/components/SemesterBox.tsx
+++ b/src/components/SemesterBox.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Lock, Unlock, MoreVertical, Trash2 } from "lucide-react";
+import { Lock, Unlock, MoreVertical, Trash2, Eraser } from "lucide-react";
 import CourseBox from "./CourseBox";
 import { useDrop } from "react-dnd";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
@@ -26,7 +26,9 @@ interface SemesterBoxProps {
         courseId?: string,
         isSuggested?: boolean
     ) => void;
+    onClearSemester: () => void;
     onRemoveSemester: () => void;
+    onShowError: (message: string) => void;
     yearKey: string;
     semesterIndex: number;
     isFromTranscript?: boolean
@@ -38,7 +40,9 @@ const SemesterBox: React.FC<SemesterBoxProps> = ({
     courses = [],
     isEmpty = false,
     onDropCourse,
+    onClearSemester,
     onRemoveSemester,
+    onShowError,
     yearKey,
     semesterIndex,
     isFromTranscript = false
@@ -48,6 +52,14 @@ const SemesterBox: React.FC<SemesterBoxProps> = ({
     const handleLockToggle = () => {
         setLocked((prev) => !prev);
     };
+
+    const handleClearClick = () => {
+        if (locked) {
+            onShowError?.(`${title} needs to be unlocked to clear courses.`);
+            return;
+        }
+        onClearSemester();
+    }
 
     const [{ isOver, canDrop }, drop] = useDrop(() => ({
         accept: "COURSE",
@@ -104,6 +116,13 @@ const SemesterBox: React.FC<SemesterBoxProps> = ({
                                 </button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
+                                <DropdownMenuItem 
+                                    className="text-amber-600 focus:text-amber-600 hover:bg-gray-100 focus:bg-gray-100 cursor-pointer data-[highlighted]:bg-gray-100 data-[highlighted]:text-amber-600"
+                                    onClick={handleClearClick}
+                                >
+                                    <Eraser className="w-4 h-4 mr-2" />
+                                    Clear Semester
+                                </DropdownMenuItem>
                                 <DropdownMenuItem 
                                     className="text-destructive focus:text-destructive hover:bg-gray-100 focus:bg-gray-100 cursor-pointer data-[highlighted]:bg-gray-100 data-[highlighted]:text-destructive"
                                     onClick={onRemoveSemester}


### PR DESCRIPTION
## SemesterBox.tsx
- check locked constraint in SemesterBox, pass setError() from parent to show error msg
- added cool jsx

## Planner.tsx
- implemented handleClearSemester logic w/ deep copy
- reused existing delete modal with additional 'action' property
- abused conditional rendering
- simplified error scroll logic

<img width="340" height="163" alt="image" src="https://github.com/user-attachments/assets/681099f3-f92e-4a43-9b54-1b94932482c9" />
<img width="466" height="195" alt="image" src="https://github.com/user-attachments/assets/4d76571f-55bc-4a45-8756-86c134e501a5" />
<img width="840" height="75" alt="image" src="https://github.com/user-attachments/assets/ebcf06c3-e326-4b76-8e52-ec8c68a39a8f" />
Closes #98 