### PR TITLE
Prevent authenticated users from accessing account login/creation routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import LoginPage from "./pages/LoginPage";
 import SignupPage from "./pages/SignUp";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage";
 import ProtectedRoute from "./components/ProtectedRoute";
+import PublicRoute from "./components/PublicRoute";
 import Planner from "./pages/Planner";
 import ChatBot from "./pages/ChatBot";
 import Profile from "./pages/Profile";
@@ -40,9 +41,30 @@ const App = () => {
           <div className="min-h-screen">
             <Routes>
               <Route path="/" element={<LandingPage />} />
-              <Route path="/login" element={<LoginPage />} />
-              <Route path="/signup" element={<SignupPage />} />
-              <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+              <Route 
+                path="/login" 
+                element={
+                  <PublicRoute>
+                    <LoginPage />
+                  </PublicRoute>
+                } 
+              />
+              <Route 
+                path="/signup" 
+                element={
+                  <PublicRoute>
+                    <SignupPage />
+                  </PublicRoute>
+                } 
+              />
+              <Route 
+                path="/forgot-password" 
+                element={
+                  <PublicRoute>
+                    <ForgotPasswordPage />
+                  </PublicRoute>
+                } 
+              />
               <Route
                 path="/planner"
                 element={

--- a/src/components/PublicRoute.tsx
+++ b/src/components/PublicRoute.tsx
@@ -1,0 +1,18 @@
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+const PublicRoute = ({ children }: { children: React.ReactNode }) => {
+    const { user, authChecking } = useAuth();
+  
+    if (authChecking) {
+        return <>{children}</>;
+      }
+
+    if (user) {
+        return <Navigate to="/" replace />;
+    }
+  
+    return <>{children}</>;
+};
+
+export default PublicRoute;

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -8,6 +8,7 @@ import {
   signInWithEmailAndPassword,
 } from "firebase/auth";
 import { auth } from "@/firebase-config";
+import { useAuth } from "@/context/AuthContext";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Toaster, toast } from "sonner";
@@ -46,6 +47,7 @@ export default function LoginForm(props: { isMobile: boolean, setLoading: (loadi
   const location = useLocation();
   const from = location.state?.from || "/chatbot";
   const [loginError, setLoginError] = useState(false);
+  const { setAuthChecking } = useAuth();
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -56,6 +58,8 @@ export default function LoginForm(props: { isMobile: boolean, setLoading: (loadi
   });
 
   const handleGoogleLogin = async () => {
+    setAuthChecking(true);
+    
     const provider = new GoogleAuthProvider();
     provider.addScope("email");
     provider.addScope("profile");
@@ -71,15 +75,18 @@ export default function LoginForm(props: { isMobile: boolean, setLoading: (loadi
       if (!email) {
         toast.error("Email is unavailable. Please try again.");
         await user.delete();
+        setAuthChecking(false);
         return;
       }
 
       if (!isAllowedInDev(email)) {
         toast.error("Development access restricted to @acmutd.co emails only.");
         await user.delete();
+        setAuthChecking(false);
         return;
       }
 
+      setAuthChecking(false);
       const token = await user.getIdToken();
       Cookies.set("authToken", token, { expires: 7 });
 
@@ -107,6 +114,7 @@ export default function LoginForm(props: { isMobile: boolean, setLoading: (loadi
     } catch (error) {
       console.error("Error during Google sign-in:", error);
       toast.error("Failed to sign in with Google. Please try again.");
+      setAuthChecking(false);
       props.setLoading(false); // Unrender loading animation for user
     }
   };

--- a/src/components/auth/signup-form.tsx
+++ b/src/components/auth/signup-form.tsx
@@ -7,6 +7,7 @@ import {
   createUserWithEmailAndPassword,
 } from "firebase/auth";
 import { auth } from "@/firebase-config";
+import { useAuth } from "@/context/AuthContext";
 import { useNavigate } from "react-router-dom";
 import Cookies from "js-cookie";
 import { Toaster, toast } from "sonner";
@@ -51,6 +52,7 @@ export default function SignupForm(props: {
   setLoading: (loading: boolean) => void;
 }) {
   const navigate = useNavigate();
+  const { setAuthChecking } = useAuth();
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -62,6 +64,7 @@ export default function SignupForm(props: {
   });
 
   const handleGoogleSignup = async () => {
+    setAuthChecking(true);
     const provider = new GoogleAuthProvider();
     provider.addScope("email");
     provider.addScope("profile");
@@ -77,14 +80,18 @@ export default function SignupForm(props: {
       if (!email) {
         toast.error("Email is unavailable. Please try again.");
         await user.delete();
+        setAuthChecking(false);
         return;
       }
 
       if (!isAllowedInDev(email)) {
         toast.error("Development access restricted to @acmutd.co emails only.");
         await user.delete();
+        setAuthChecking(false);
         return;
       }
+
+      setAuthChecking(false);
 
       const token = await user.getIdToken();
       Cookies.set("authToken", token, { expires: 7 });
@@ -113,6 +120,7 @@ export default function SignupForm(props: {
     } catch (error) {
       console.error("Error during Google sign-up:", error);
       toast.error("Failed to sign up with Google. Please try again.");
+      setAuthChecking(false);
       props.setLoading(false); // Unrender loading animation for user
     }
   };

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -14,6 +14,8 @@ interface AuthContextType {
   loading: boolean;
   logout: () => void;
   profilePicture: string | null;
+  authChecking: boolean;
+  setAuthChecking: (checking: boolean) => void;
 }
 
 const AuthContext = createContext<AuthContextType>({
@@ -21,6 +23,8 @@ const AuthContext = createContext<AuthContextType>({
   loading: true,
   logout: () => {},
   profilePicture: null,
+  authChecking: false,
+  setAuthChecking: () => {},
 });
 
 const CRUD_API = import.meta.env.VITE_CRUD_API as string | undefined;
@@ -33,6 +37,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [profilePicture, setProfilePicture] = useState(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const [authChecking, setAuthChecking] = useState(false);
 
   useEffect(() => {
     const initializeAuth = async () => {
@@ -95,7 +100,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, logout, profilePicture }}>
+    <AuthContext.Provider value={{ user, loading, logout, profilePicture, authChecking, setAuthChecking, }}>
       {!loading && children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
- while it hasn't been caught, to prevent users from going into their URL and directly typing in /login, /signup, or /forgot-password, a Public Route component is made to prevent accessing those endpoints unless they're logged out
 - If they attempt to do this, SAGE redirects back to the home page
- encountered a particular race condition that occurs if an unauthorized user (just for the development mode) tries logging in but it actually fulfills the public route. Therefore, added in a early stop condition to retain them in the page until auth flow is fulfilled.