### PR TITLE
Add in auth hoist for firebase token refresh

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { auth } from "../firebase-config";
+import { getToken } from "@/utils/auth";
 import {
   onAuthStateChanged,
   User,
@@ -67,7 +68,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
           if (user) {
             setUser(user);
-            const token = await user.getIdToken();
+            const token = await getToken(user);
 
             if (import.meta.env.MODE !== "development") {
               loadClarity(import.meta.env.VITE_CLARITY_PROJECT_ID);

--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -8,6 +8,7 @@ import { MultiBackend, TouchTransition, MouseTransition } from "react-dnd-multi-
 import { useAuth } from "@/context/AuthContext";
 import { usePlannerStore } from "@/stores/plannerStore";
 import { toast } from "sonner";
+import { getToken } from "@/utils/auth";
 
 type PlanConflictOption = "overwrite" | "select" | "new";
 
@@ -192,7 +193,7 @@ const PlannerPage = () => {
       return;
     }
 
-    const token = await user.getIdToken();
+    const token = await getToken(user);
     if (!token) {
       sessionStorage.setItem('hasCheckedCloudThisSession', 'true');
       return;
@@ -268,7 +269,7 @@ const PlannerPage = () => {
       const controller = new AbortController();
       fetchAbortRef.current = controller;
 
-      const token = await user.getIdToken();
+      const token = await getToken(user);
       if (!token) throw new Error("Failed to retrieve auth token.");
 
       const response = await fetch(VITE_EVALUATOR_API, {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,9 @@
+import { User } from "firebase/auth";
+
+export async function getToken(user: User, forceRefresh = false): Promise<string> {
+    try {
+      return await user.getIdToken(forceRefresh);
+    } catch {
+      return await user.getIdToken(true); // If getting the token failed, try forcing a refresh once
+    }
+}

--- a/src/utils/evaluatePlanner.ts
+++ b/src/utils/evaluatePlanner.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/firebase-config";
+import { getToken } from "@/utils/auth";
 
 function getPlannerState(): any {
   const raw = localStorage.getItem("planner-state");
@@ -304,7 +305,7 @@ async function requestPlannerEvaluation(
 ): Promise<any> {
   const user = auth.currentUser;
   if (!user) throw new Error("No auth token found — are you logged in?");
-  const token = await user.getIdToken();
+  const token = await getToken(user);
 
   const id = user.uid;
   if (!id) throw new Error("No account ID found for user");


### PR DESCRIPTION
- so as it turns out, an edge case (well only happens to me) is if Firebase accidentally keeps a stale UID and doesn't refresh the token at will.
 - now, what this does is it force refreshes that token and gives it back a new UID (which I happened to have) and should improve user experience of the application without having errors related to a stale UID