### PR TITLE
Bug: Using transcriptData UID rather than user.uid

### DIFF
--- a/src/pages/PlannerPage.tsx
+++ b/src/pages/PlannerPage.tsx
@@ -275,7 +275,7 @@ const PlannerPage = () => {
       const response = await fetch(VITE_EVALUATOR_API, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: transcriptData?.id || "student123", transcriptData, token }),
+        body: JSON.stringify({ id: user.uid || "student123", transcriptData, token }),
         signal: controller.signal,
       });
 


### PR DESCRIPTION
- we want to use user.uid instead of transcriptData.id
 - why? It is susceptable to stale firebase data if for some reason Firebase refreshes a user's UID; therefore, always use firebase's user UID