### PR TITLE
Propagate mobile view to have filtering of latest semester offerings …

### DIFF
--- a/src/components/planner/PlannerSidebarContent.tsx
+++ b/src/components/planner/PlannerSidebarContent.tsx
@@ -32,6 +32,15 @@ interface PlannerSidebarContentProps {
   onOpenDiscovery?: () => void;
 }
 
+const formatCoursebookSemester = (sem: string | null): string | null => {
+  if (!sem) return null;
+  const match = sem.match(/^(\d{2})([suf])$/);
+  if (!match) return null;
+  const year = `20${match[1]}`;
+  const name = { s: "Spring", u: "Summer", f: "Fall" }[match[2]] ?? "";
+  return `${name} ${year}`;
+};
+
 const PlannerSidebarContent: React.FC<PlannerSidebarContentProps> = ({
   onClose,
   requirements,
@@ -51,6 +60,7 @@ const PlannerSidebarContent: React.FC<PlannerSidebarContentProps> = ({
   const [autoExpandedCategories, setAutoExpandedCategories] = React.useState<{ [key: number]: boolean }>({});
   const [expandedSubcategories, setExpandedSubcategories] = React.useState<Record<string, boolean>>({});
   const prevSuggestedByKeyRef = useRef<Record<string, Set<string>>>({});
+  const [showAvailableOnly, setShowAvailableOnly] = React.useState(false);
 
   // Course discovery store
   const stagedCourses = usePlannerStore(s => s.stagedCourses);
@@ -332,6 +342,7 @@ const PlannerSidebarContent: React.FC<PlannerSidebarContentProps> = ({
               <CoursesCarousel
                 courses={category.suggested}
                 type="suggested"
+                showAvailableOnly={showAvailableOnly}
                 placedSuggestedCourses={placedSuggestedCourses}
                 categoryName={category.name}
                 availableSemesters={availableSemesters}
@@ -430,9 +441,29 @@ const PlannerSidebarContent: React.FC<PlannerSidebarContentProps> = ({
         </div>
       )}
 
-      <h2 className="text-xl font-bold text-gray-900 mb-4">
-        Degree Requirements
-      </h2>
+      <div className="mb-4">
+        <h2 className="text-xl font-bold text-gray-900 mb-2">
+          Degree Requirements
+        </h2>
+        <div className="flex items-center gap-2.5 px-2.5 py-2 bg-white border border-gray-200 rounded-xl">
+          <button
+            role="switch"
+            aria-checked={showAvailableOnly}
+            onClick={() => setShowAvailableOnly(prev => !prev)}
+            className={`relative w-9 h-5 rounded-full transition-colors duration-200 flex-shrink-0 focus:outline-none ${showAvailableOnly ? 'bg-green-500' : 'bg-gray-300'
+              }`}
+          >
+            <span className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-all duration-200 ${showAvailableOnly ? 'left-[18px]' : 'left-0.5'
+              }`} />
+          </button>
+          <label
+            className="text-xs text-gray-500 cursor-pointer select-none"
+            onClick={() => setShowAvailableOnly(prev => !prev)}
+          >
+            {coursebookSemester ? `Show ${formatCoursebookSemester(coursebookSemester)} offerings` : 'Show available sections only'}
+          </label>
+        </div>
+      </div>
 
       <div className="space-y-3 pb-6">
         {requirements.map((req, reqIdx) => {


### PR DESCRIPTION
…for classes

- sometimes, students on mobile may want to also have the ability to filter latest coursebook class offerings in their degree planning (again this feature is default off but we set this to "false" since this planner is meant for long-form planning rather than short-term