### PR TITLE
hot-fix: make button not wrap

### DIFF
--- a/src/pages/ChatBot.tsx
+++ b/src/pages/ChatBot.tsx
@@ -831,7 +831,7 @@ const ChatBot: React.FC = () => {
               {!sidebarCollapsed && (
                 <div className={`${sidebarCollapsedDelayed ? "opacity-0" : "opacity-100"} flex flex-col w-full overflow-visible gap-8 transition-all duration-150`}>
                   <div className="flex gap-3 justify-between items-center">
-                    <button data-tour="new-chat-expanded" aria-label="Start a new chat conversation" className="flex transition-all duration-100 items-center space-x-2 py-2 px-6 rounded-3xl bg-accent text-textdark hover:text-gray-700" onClick={startNewChat}>
+                  <button data-tour="new-chat-expanded" aria-label="Start a new chat conversation" className="flex shrink-0 whitespace-nowrap transition-all duration-100 items-center space-x-2 py-2 px-6 rounded-3xl bg-accent text-textdark hover:text-gray-700" onClick={startNewChat}>
                       <MessageCirclePlusIcon size={24} aria-hidden="true" />
                       <span>Start new chat</span>
                     </button>


### PR DESCRIPTION
- noticed that the button should definently not wrap for when it is in loading conversations or if no conversations are available.